### PR TITLE
add lambda handler for loading uci riders into s3

### DIFF
--- a/src/handlers/LoadRiderHandler.ts
+++ b/src/handlers/LoadRiderHandler.ts
@@ -1,0 +1,62 @@
+import { uploadObject } from '../s3/S3Service.js';
+import { getRankings, getRiders } from '../scrappers/proCyclingStatScrapper.js';
+import { Rank, Rider } from '../types/CyclingTypes.js';
+import { HandlerResponse } from '../types/ResponseTypes.js';
+import { chunk } from '../utils/arrayUtils.js';
+import { getMaxMemoryConsumed } from '../utils/statUtils.js';
+
+export { handleLoadRiders };
+
+/**
+ *
+ * @param event The lambda event provided to the function
+ * @param context The lambda context provided to the function
+ * @param callback Callback to call at the end of the function
+ */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function handleLoadRiders(event: unknown, context: unknown, callback: unknown): Promise<HandlerResponse> {
+    const startDate: Date = new Date();
+
+    if (!process.env.RIDERS_FILE_NAME) throw new Error('RIDERS_FILE_NAME environment variable not defined');
+    if (!process.env.RIDERS_BUCKET_NAME) throw new Error('RIDERS_FILE_NAME environment variable not defined');
+
+    try {
+        const riders: Rider[] = [];
+
+        for (let i = 0; i <= 9; i++) {
+            const rankings: Rank[] = await getRankings(i);
+            const rankingsMap: Rank[][] = chunk(rankings, 20);
+
+            // To avoid banning the ip and getting oom
+            for (const rankingsElement of rankingsMap) {
+                const riderResults: Rider[] = await getRiders(rankingsElement);
+                riders.push(...riderResults);
+            }
+        }
+
+        await uploadObject(
+            riders,
+            process.env.RIDERS_FILE_NAME,
+            process.env.RIDERS_BUCKET_NAME,
+            "ONEZONE_IA",
+            "public-read"
+        );
+
+        const endDate: Date = new Date();
+        const runTime: number = (endDate.getTime() - startDate.getTime()) / 1000;
+        return {
+            body: `Successfully uploaded ${riders.length} riders with a maximum memory consumption of ${getMaxMemoryConsumed()}MB in ${runTime?.toFixed(2)}s`,
+            statusCode: 200
+        };
+    } catch (e: unknown) {
+        const err: Error = e as Error;
+        const endDate: Date = new Date();
+        const runTime: number = (endDate.getTime() - startDate.getTime()) / 1000;
+        return {
+            body: `Failed importing riders (duration ${runTime?.toFixed(2)}s) with error ${err?.message || 'Unknown error'}: ${err?.stack || 'Unknown stacktrace'}`,
+            statusCode: 500
+        };
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
-import { testFunction } from "./testModule/testFunction.js";
+import { handleLoadRiders } from './handlers/LoadRiderHandler.js';
 
-console.log(testFunction("message from index"));
+export {
+    handleLoadRiders
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,6 @@
+import 'dotenv/config';
+import { handleLoadRiders } from "./handlers/LoadRiderHandler.js";
+
+handleLoadRiders(null, null, null)
+    .then((res) => console.log(res))
+    .catch((res) => console.error(res));

--- a/src/s3/S3Service.ts
+++ b/src/s3/S3Service.ts
@@ -1,0 +1,34 @@
+import { ObjectCannedACL, PutObjectCommand, S3Client, StorageClass } from '@aws-sdk/client-s3';
+
+/**
+ *
+ * @param object The javascript object you want to upload
+ * @param filename The name of the file containing the object
+ * @param bucket Name of the bucket to which the file will be uploaded
+ * @param storageClass Name of the bucket to which the file will be uploaded
+ * @param acl Name of the bucket to which the file will be uploaded
+ */
+export async function uploadObject(object: unknown, filename: string, bucket: string, storageClass?: StorageClass, acl?: ObjectCannedACL): Promise<void> {
+    if (!process.env.S3_ACCESS_KEY) throw Error('S3_ACCESS_KEY environment variable not defined');
+    if (!process.env.S3_SECRET_KEY) throw Error('S3_SECRET_KEY environment variable not defined');
+    if (!process.env.S3_DOMAIN) throw Error('S3_DOMAIN environment variable not defined');
+
+    const client: S3Client = new S3Client({
+        endpoint: `https://${process.env.S3_DOMAIN}`,
+        credentials: {
+            accessKeyId: process.env.S3_ACCESS_KEY,
+            secretAccessKey: process.env.S3_SECRET_KEY
+        },
+        region: process.env.S3_REGION
+    });
+
+    const command: PutObjectCommand = new PutObjectCommand({
+        Bucket: bucket,
+        Key: filename,
+        Body: JSON.stringify(object),
+        StorageClass: storageClass || "STANDARD",
+        ACL: acl || "private"
+    });
+
+    await client.send(command);
+}

--- a/src/scrappers/proCyclingStatScrapper.ts
+++ b/src/scrappers/proCyclingStatScrapper.ts
@@ -1,0 +1,111 @@
+import axios, { AxiosResponse } from 'axios';
+import { JSDOM } from 'jsdom';
+
+import { Rank, Rider } from '../types/CyclingTypes.js';
+import { memoryStats } from '../utils/statUtils.js';
+
+/**
+ * @param index The index of the page required (if set to in, rankings from 100 to 200 are returned)
+ * @return Between 0 and 100 rankings
+ * */
+export async function getRankings(index: number): Promise<Rank[]> {
+    const results: Rank[] = [];
+
+    let response: AxiosResponse<unknown> | null = await axios.get(`https://www.procyclingstats.com/rankings.php?page=smallerorequal&offset=${index}00&filter=Filter`);
+
+    if (typeof response?.data != 'string') {
+        throw new Error("Unable to parse data from 'https://www.procyclingstats.com/rankings.php?page=smallerorequal&offset=${index}00&filter=Filter' - it's not a string");
+    }
+
+    let doc: Document | null = new JSDOM(response?.data).window.document;
+    response = null; // free memory asap
+
+    const table: HTMLTableElement | null = doc.querySelector('table');
+    doc = null; // free memory asap
+
+    if (!table || !table.rows) {
+        throw new Error("Unable to parse data from 'https://www.procyclingstats.com/rankings.php?page=smallerorequal&offset=${index}00&filter=Filter' - ranking table not found");
+    }
+    if (table.rows.length === 0) {
+        return [];
+    }
+
+    for (let j = 1; j < table.rows.length; j++) {
+        const row: HTMLTableRowElement = table.rows[j];
+        const cell: HTMLTableCellElement = row.cells[3];
+        const href: string | undefined = cell.innerHTML.match(/<a[^>]* href="([^"]*)"/)?.[1];
+
+        // if unable to parse a rank, skip it
+        if (row.cells[0].textContent && href) results.push({
+            rank: row.cells[0].textContent,
+            riderLink: href
+        });
+    }
+
+    const errorRate = (table.rows.length - results.length) / table.rows.length;
+    if (errorRate > 0.1) {
+        throw new Error(`Error rate while parsing ranks is too high (${errorRate})`);
+    }
+
+    return results;
+}
+
+/**
+ * @param ranks The ranks objects, so you want the corresponding riders
+ * @return between 0 and 100 rankings
+ * */
+export async function getRiders(ranks: Rank[]): Promise<Rider[]> {
+    const riders: Promise<Rider | null>[] = [];
+
+    for (let i = 0; i < ranks.length; i++) {
+        riders.push(getRider(ranks[i]));
+        if (i % 10 === 0) await new Promise(resolve => setTimeout(resolve, 500));
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return (await Promise.all(riders)).filter((e) => !!e).map((e) => e!);
+}
+
+/**
+ * @param rank The rank object so you want the corresponding rider
+ * @return between 0 and 100 rankings
+ * */
+async function getRider(rank: Rank): Promise<Rider | null> {
+    const headers = {
+        'Referer': 'https://www.procyclingstats.com/',
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36'
+    };
+    let response: AxiosResponse<unknown> | null = await axios.get(`https://www.procyclingstats.com/${rank.riderLink}`, { headers: headers });
+
+    if (typeof response?.data !== 'string') return null;
+
+    let doc: Document | null = new JSDOM(response.data).window.document;
+    response = null;
+
+    const infoElement: Element | null = doc.getElementsByClassName('rdr-info-cont').item(0);
+    const titleElement: HTMLHeadingElement | null = doc.querySelector('h1');
+    doc = null;
+
+    const ranking: string | undefined = infoElement?.innerHTML.match(/<a href="rankings\/me\/uci-individual">UCI World<\/a>[^<]*<\/div>[^<]*<div class="rnk[^"]*">(\d*)<\/div>/)?.[1];
+    const age: string | undefined = infoElement?.innerHTML.match(/\((\d*)\)<br><b>Nationality/)?.[1];
+    const country: string | undefined = infoElement?.innerHTML.match(/href="nation\/([^"]*)"/)?.[1];
+    const weight: string | undefined = infoElement?.innerHTML.match(/<b>Weight:<\/b>\s*(\d*)\s*kg/)?.[1];
+    const height: string | undefined = infoElement?.innerHTML.match(/<b>Height:<\/b>\s*(\d*.\d*)\s*m/)?.[1];
+
+    const name: string | undefined = titleElement?.innerHTML.replace('  ', ' ');
+
+    if (!height || !weight || !country || !age || !ranking || !name) {
+        return null;
+    }
+
+    memoryStats();
+
+    return {
+        rank: parseInt(ranking),
+        name: name,
+        country: country,
+        age: parseInt(age, 10),
+        weight: parseInt(weight),
+        height: parseFloat(height)
+    };
+}

--- a/src/testModule/testFunction.ts
+++ b/src/testModule/testFunction.ts
@@ -1,3 +1,0 @@
-export function testFunction(testMessage: string): string {
-    return `this is a test with message: ${testMessage}`;
-}

--- a/src/types/CyclingTypes.ts
+++ b/src/types/CyclingTypes.ts
@@ -1,0 +1,21 @@
+export type Rank = {
+    rank: string,
+    riderLink: string
+}
+
+/**
+ * @param rank The UCI rank of the rider
+ * @param name The name of the rider
+ * @param country The country of the rider
+ * @param age The age of the rider
+ * @param weight Rider's weight (in kg)
+ * @param height Rider's height (in meter)
+ */
+export type Rider = {
+    rank: number,
+    name: string,
+    country: string,
+    age: number,
+    weight: number,
+    height: number
+}

--- a/src/types/ResponseTypes.ts
+++ b/src/types/ResponseTypes.ts
@@ -1,0 +1,8 @@
+/**
+ * @property body The human readable body return by the function
+ * @property body The http status code corresponding to the response
+ */
+export type HandlerResponse = {
+    body: string,
+    statusCode: number
+}

--- a/src/utils/arrayUtils.ts
+++ b/src/utils/arrayUtils.ts
@@ -1,0 +1,13 @@
+/**
+ * @param arr the array to splint into chunks
+ * @param chunkSize the maximum size of each chunk
+ * @return the array divided into multiple chunks
+ */
+export function chunk<T>(arr: T[], chunkSize: number): T[][] {
+    const res: T[][] = [];
+    for (let i = 0; i < arr.length; i += chunkSize) {
+        const chunk:T[] = arr.slice(i, i + chunkSize);
+        res.push(chunk);
+    }
+    return res;
+}

--- a/src/utils/statUtils.ts
+++ b/src/utils/statUtils.ts
@@ -1,0 +1,25 @@
+/**
+ * Stores the heap total in maxMemConsumed if it's the maximum since the start of the process
+ */
+export function memoryStats() {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    if (!global.maxMemConsumed) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        global.maxMemConsumed = process.memoryUsage().heapTotal/1000000;
+    } else {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        global.maxMemConsumed = Math.max(global.maxMemConsumed, process.memoryUsage().heapTotal/1000000);
+    }
+}
+
+/**
+ * @return the highest value of heap size registered in MB
+ */
+export function getMaxMemoryConsumed(): number {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    return global.maxMemConsumed;
+}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Purpose of this PR is to providle a new aws lambda handler to upload uci riders into a s3 bucket

- **What is the current behavior?** (You can also link to an open issue here)
N/A

- **What is the new behavior (if this is a feature change)?**
index export handleLoadRiders

- **Other information**:
Lambda handler is designed to run on a container providing minimum 4GB of memory